### PR TITLE
discard local changes when syncing distgit repos

### DIFF
--- a/verwatch/fetchers/distgit.py
+++ b/verwatch/fetchers/distgit.py
@@ -10,7 +10,7 @@ class DistGitFetcher(GitFetcher):
     name = 'distgit'
 
     def _checkout(self, branch):
-        self.cmd = 'git checkout "%s"' % branch
+        self.cmd = 'git checkout --force "%s"' % branch
         errc, out, err = run(self.cmd)
         if errc:
             raise RuntimeError("git checkout failed: %s" % err or out)


### PR DESCRIPTION
This may be due to a previous version of verwatch
leaving the repos in an unclean state, or even
local changes made by users in the cache dir.
