### PR TITLE
Add blessings dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,11 @@ setuptools.setup(
     entry_points={
         "console_scripts": ["verw = verwatch.shell:main"]
     },
+    tests_require=[
+        'pytest'
+    ],
     install_requires=[
         "blessings",
+        "docopt",
     ],
     )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 import setuptools
-from verwatch.core import VERSION
+
+VERSION = "0.6"
 
 setuptools.setup(
     name='verwatch',
@@ -13,5 +14,8 @@ setuptools.setup(
     packages=['verwatch','verwatch.fetchers'],
     entry_points={
         "console_scripts": ["verw = verwatch.shell:main"]
-    }
+    },
+    install_requires=[
+        "blessings",
+    ],
     )

--- a/verwatch/core.py
+++ b/verwatch/core.py
@@ -6,9 +6,9 @@ import fetch
 import re
 import yaml
 import blessings
+import pkg_resources
 
-
-VERSION = '0.6'
+VERSION = pkg_resources.get_distribution('verwatch').version
 
 TERM = blessings.Terminal()
 TERM_PLAIN = util.PlainTerminal()


### PR DESCRIPTION
Also set the `VERSION` in setup.py and use pkg_resources to get it in the
app itself. This lets the dependencies be installed _before_ running any
verwatch code.
